### PR TITLE
Rework to be able to build against system fcl and master openrave

### DIFF
--- a/catkin.cmake
+++ b/catkin.cmake
@@ -1,20 +1,46 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(or_fcl)
 
+include(FindPkgConfig)
+include(CheckCXXSourceCompiles)
+
 ## Find catkin macros and libraries
 ## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
 ## is used, also find other catkin packages
-find_package(catkin REQUIRED COMPONENTS openrave_catkin fcl)
+find_package(catkin REQUIRED COMPONENTS openrave_catkin)
 find_package(Boost REQUIRED COMPONENTS system)
+find_package(OpenRAVE REQUIRED)
+
+# fcl
+find_package(fcl)
+if (NOT fcl_FOUND)
+    pkg_check_modules(fcl fcl)
+endif()
+if (NOT fcl_FOUND)
+    MESSAGE(FATAL_ERROR "fcl not found (either through cmake or pkg-config)")
+endif()
+
+set(CMAKE_REQUIRED_INCLUDES ${OpenRAVE_INCLUDE_DIRS})
+set(CMAKE_REQUIRED_LIBRARIES ${OpenRAVE_LIBRARIES})
+check_cxx_source_compiles("
+    #include <openrave/openrave.h>
+    int main() {
+    OpenRAVE::CollisionReport r;
+    r.vLinkColliding.push_back(std::make_pair(OpenRAVE::KinBody::LinkConstPtr(),OpenRAVE::KinBody::LinkConstPtr()));
+    }" HAVE_REPORT_VLINKCOLLIDING_PAIR
+)
+if (HAVE_REPORT_VLINKCOLLIDING_PAIR)
+    add_definitions(-DHAVE_REPORT_VLINKCOLLIDING_PAIR)
+endif ()
 
 add_definitions(--std=c++0x -O3)
-include_directories(${catkin_INCLUDE_DIRS})
-link_directories(${catkin_LIBRARY_DIRS})
+include_directories(${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} ${fcl_INCLUDE_DIRS})
+link_directories(${catkin_LIBRARY_DIRS} ${Boost_LIBRARY_DIRS} ${fcl_LIBRARY_DIRS})
 
 catkin_package(
     INCLUDE_DIRS src
     LIBRARIES ${PROJECT_NAME}
-    CATKIN_DEPENDS fcl openrave_catkin
+    CATKIN_DEPENDS openrave_catkin
 )
 
 openrave_plugin(${PROJECT_NAME}_plugin
@@ -24,4 +50,5 @@ openrave_plugin(${PROJECT_NAME}_plugin
 target_link_libraries(${PROJECT_NAME}_plugin
     ${catkin_LIBRARIES}
     ${Boost_LIBRARIES}
+    ${fcl_LIBRARIES}
 )

--- a/src/FCLCollisionChecker.cpp
+++ b/src/FCLCollisionChecker.cpp
@@ -506,16 +506,8 @@ bool FCLCollisionChecker::RunCheck(
     }
 
     // Initialize the report.
-    if (report) {
-        report->options = options_;
-        report->plink1.reset(); 
-        report->plink2.reset(); 
-        report->numCols = 0;
-        report->vLinkColliding.clear();
-        report->minDistance = std::numeric_limits<OpenRAVE::dReal>::max();
-        report->numWithinTol = 0;
-        report->contacts.clear();
-    }
+    if (report)
+        report->Reset(options_);
 
     manager1_->collide(manager2_.get(), &query,
                        &FCLCollisionChecker::NarrowPhaseCheckCollision);
@@ -791,7 +783,12 @@ bool FCLCollisionChecker::NarrowPhaseCheckCollision(
         if (query->report) {
             query->report->plink1 = GetCollisionLink(*o1);
             query->report->plink2 = GetCollisionLink(*o2);
+#ifdef HAVE_REPORT_VLINKCOLLIDING_PAIR
+            query->report->vLinkColliding.push_back(std::make_pair(
+                query->report->plink1,query->report->plink2));
+#else
             query->report->vLinkColliding.push_back(query->report->plink2);
+#endif
             // TODO: Update numCols.
 
             if (query->request.enable_contact) {


### PR DESCRIPTION
When FCL is installed from source (e.g. from the upstream `https://github.com/flexible-collision-library/fcl`), it does not install a cmake file, but does install a pkg-config file.  This PR tries both methods for finding FCL.

Also, some internals of the `OpenRAVE::CollisionReport` structure have changed recently.  This PR contains configuration-time check to determine which version of OpenRAVE you're building against.  It also uses the built-in `CollisionReport::Reset` method to initialize the report instead of manually resetting each member.