### PR TITLE
Fix CheckCollision(link1,link2) bug when links are part of the same kinbody

### DIFF
--- a/src/FCLCollisionChecker.cpp
+++ b/src/FCLCollisionChecker.cpp
@@ -310,6 +310,12 @@ bool FCLCollisionChecker::CheckCollision(
     if (!link1->IsEnabled() || !link2->IsEnabled())
         return false;
 
+    boost::unordered_set<LinkPair> disabled_pairs;
+    boost::unordered_set<LinkPair> self_enabled_pairs;
+    if (link1->GetParent() == link2->GetParent()) {
+        self_enabled_pairs.insert(MakeLinkPair(link1.get(), link2.get()));
+    }
+
     // Group 1: link1.
     manager1_->clear();
     SynchronizeLink(GetCollisionData(link1->GetParent()), link1.get(), &group1);
@@ -322,7 +328,7 @@ bool FCLCollisionChecker::CheckCollision(
     manager2_->registerObjects(group2);
     manager2_->setup();
 
-    return RunCheck(report);
+    return RunCheck(report, disabled_pairs, self_enabled_pairs);
 }
 
 /* checks collision of a link and a body.

--- a/src/FCLCollisionChecker.cpp
+++ b/src/FCLCollisionChecker.cpp
@@ -77,6 +77,7 @@ typedef OpenRAVE::KinBody::JointPtr JointPtr;
 typedef OpenRAVE::RobotBase::GrabbedInfoPtr GrabbedInfoPtr;
 typedef OpenRAVE::EnvironmentBase::CollisionCallbackFn CollisionCallbackFn;
 
+
 namespace {
 
 /*

--- a/tests/test_collision_checks.py
+++ b/tests/test_collision_checks.py
@@ -208,6 +208,25 @@ class ORFCLTest(unittest.TestCase):
         self.assertTrue(self.penv.CheckCollision(cylinder, robot))
         self.assertFalse(self.penv.CheckCollision(robot))
         self.assertTrue(self.penv.CheckCollision(cylinder))
+
+    def test_collisionLinkLink(self):
+        robot = self.penv.ReadRobotXMLFile('robots/barrettwam.robot.xml')
+        self.penv.Add(robot)
+        arm = robot.GetManipulator('arm')
+        robot.SetActiveDOFs(robot.GetActiveManipulator().GetArmIndices())
+        
+        # this is a known colliding configuration between the base and hand
+        robot.SetActiveDOFValues([0., 1.8, 0., 2.8, 0., 0., 0.])
+        
+        # get links
+        link1 = robot.GetLink('wam0')
+        link2 = robot.GetLink('handbase')
+        self.assertTrue(link1 is not None)
+        self.assertTrue(link2 is not None)
+        
+        # validate result
+        self.assertTrue(self.penv.CheckCollision(link1, link2))
+        
     
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This adds (1) a new unit test and (2) an associated bugfix for the `CheckCollision(link1,link2)` when both links are a member of the same kinbody.  The `self_enabled_pairs` argument to `RunCheck` was not being correctly populated in this case.  See issue #15.