### PR TITLE
Suppress find_package warnings with pkg-config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/CXX11.cmake")
 find_package(Boost REQUIRED COMPONENTS system)
 find_package(OpenRAVE REQUIRED)
 
-find_package(fcl)
+find_package(fcl QUIET)
 if (NOT fcl_FOUND)
   pkg_check_modules(fcl fcl)
 endif()


### PR DESCRIPTION
I noticed in #17 that CMake prints a warning if we fail to `find_package` FCL, even if we later successfully find it using `pkg-config`. This pull request fixes that by passing the `QUIET` option.