### PR TITLE
Add missing boost variables so configuration check compiles correctly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,8 +30,8 @@ link_directories(
 )
 
 # Check for OpenRAVE features.
-set(CMAKE_REQUIRED_INCLUDES ${OpenRAVE_INCLUDE_DIRS})
-set(CMAKE_REQUIRED_LIBRARIES ${OpenRAVE_LIBRARIES})
+set(CMAKE_REQUIRED_INCLUDES ${Boost_INCLUDE_DIRS} ${OpenRAVE_INCLUDE_DIRS})
+set(CMAKE_REQUIRED_LIBRARIES ${Boost_LIBRARIES} ${OpenRAVE_LIBRARIES})
 check_cxx_source_compiles("
   #include <openrave/openrave.h>
   int main() {


### PR DESCRIPTION
I was finally able to reproduce the bug in the configuration check discovered by @Softwaretom007 in #17.  Here's the error log (`build/CMakeFiles/CMakeError.log`):

    /usr/bin/c++ -DHAVE_REPORT_VLINKCOLLIDING_PAIR CMakeFiles/cmTryCompileExec3806937907.dir/src.cxx.o -o cmTryCompileExec3806937907 -rdynamic -lopenrave0.9 
    /usr/bin/ld: CMakeFiles/cmTryCompileExec3806937907.dir/src.cxx.o: undefined reference to symbol '_ZN5boost6system15system_categoryEv'
    //usr/lib/x86_64-linux-gnu/libboost_system.so.1.54.0: error adding symbols: DSO missing from command line
    collect2: error: ld returned 1 exit status

The fix was simple: add the Boost headers/libs for the checking code.