### PR TITLE
Fix OpenRAVE path munging order for overlays

### DIFF
--- a/catkin-env-hooks/20.or_fcl.sh.in
+++ b/catkin-env-hooks/20.or_fcl.sh.in
@@ -8,11 +8,11 @@ else
   PLUGINS=@CMAKE_INSTALL_PREFIX@/share/openrave-@OpenRAVE_LIBRARY_SUFFIX@/plugins
 fi 
 
-# append to paths (if not already there)
+# prepend to paths (if not already there)
 # from http://unix.stackexchange.com/a/124447
 case ":${OPENRAVE_PLUGINS:=$PLUGINS}:" in
     *:$PLUGINS:*) ;;
-    *) OPENRAVE_PLUGINS="$OPENRAVE_PLUGINS:$PLUGINS" ;;
+    *) OPENRAVE_PLUGINS="$PLUGINS:$OPENRAVE_PLUGINS" ;;
 esac
 
 export OPENRAVE_PLUGINS


### PR DESCRIPTION
When a new version of this package is overlayed above a workspace containing an old version of this package, the `OPENRAVE_PLUGINS` variable was not being set correctly, causing the wrong module to be loaded.